### PR TITLE
fix(github): add retry mechanism for mergeability check

### DIFF
--- a/pkg/adapters/github/mock.gen.go
+++ b/pkg/adapters/github/mock.gen.go
@@ -42,10 +42,10 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // CheckMergeConflicts mocks base method.
-func (m *MockClient) CheckMergeConflicts(ctx context.Context, params CheckMergeConflictsParams) (*MergeConflictInfo, error) {
+func (m *MockClient) CheckMergeConflicts(ctx context.Context, params CheckMergeConflictsParams) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckMergeConflicts", ctx, params)
-	ret0, _ := ret[0].(*MergeConflictInfo)
+	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/depsync/depsync.go
+++ b/pkg/depsync/depsync.go
@@ -290,7 +290,7 @@ func (c *DepSync) handlePRConflicts(ctx context.Context, service, dep string, _ 
 		zap.Int("pr_number", prNumber))
 
 	// Check for merge conflicts
-	conflictInfo, err := c.client.CheckMergeConflicts(ctx, github.CheckMergeConflictsParams{
+	hasConflicts, err := c.client.CheckMergeConflicts(ctx, github.CheckMergeConflictsParams{
 		RepoURL:  repoURL,
 		PRNumber: prNumber,
 	})
@@ -299,7 +299,7 @@ func (c *DepSync) handlePRConflicts(ctx context.Context, service, dep string, _ 
 		return false, err
 	}
 
-	if !conflictInfo.HasConflicts {
+	if !hasConflicts {
 		logger.Info("No conflicts detected in PR")
 		return false, nil
 	}
@@ -307,8 +307,7 @@ func (c *DepSync) handlePRConflicts(ctx context.Context, service, dep string, _ 
 	logger.Info("Conflicts detected in PR, deleting PR and branch",
 		zap.String("service", service),
 		zap.String("dependency", dep),
-		zap.Int("pr_number", prNumber),
-		zap.Strings("conflicted_files", conflictInfo.ConflictedFiles))
+		zap.Int("pr_number", prNumber))
 
 	// Delete the conflicted PR and branch
 	if err := c.deleteConflictedPR(ctx, service, dep, repoURL, prNumber, branchName); err != nil {

--- a/pkg/depsync/depsync_delete_conflicted_prs_test.go
+++ b/pkg/depsync/depsync_delete_conflicted_prs_test.go
@@ -82,10 +82,7 @@ func TestDepSync_Run_WithRepositories_DeleteConflictedPRsEnabled(t *testing.T) {
 			RepoURL:  "https://github.com/test/repo",
 			PRNumber: 123,
 		},
-	).Return(&github.MergeConflictInfo{
-		HasConflicts:    true,
-		ConflictedFiles: []string{"go.mod", "go.sum"},
-	}, nil)
+	).Return(true, nil)
 
 	// Mock the deletion operations
 	tc.MockGitHubClient.EXPECT().DeletePullRequest(
@@ -268,10 +265,7 @@ func TestDepSync_Run_WithRepositories_DeleteConflictedPRsError(t *testing.T) {
 			RepoURL:  "https://github.com/test/repo",
 			PRNumber: 123,
 		},
-	).Return(&github.MergeConflictInfo{
-		HasConflicts:    true,
-		ConflictedFiles: []string{"go.mod", "go.sum"},
-	}, nil)
+	).Return(true, nil)
 
 	// Mock the deletion operations - PR deletion fails
 	tc.MockGitHubClient.EXPECT().DeletePullRequest(


### PR DESCRIPTION
- Add exponential backoff retry logic when GitHub API returns 'unknown' mergeability status
- Extract retry logic into separate helper function to maintain code quality
- Add proper logging for retry attempts to improve debugging
- Fixes issue where depsync would fail immediately when GitHub hasn't computed mergeability yet
